### PR TITLE
Add #2 (delete stocks from portfolio)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -240,6 +240,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  rflutter_alert:
+    dependency: "direct main"
+    description:
+      name: rflutter_alert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   cloud_firestore: ^0.13.7
   modal_progress_hud: ^0.1.3
   intl: ^0.16.1
+  rflutter_alert: ^1.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Solved #2 by adding an alert that displays the complete purchase and sell-by date information for the selected stock. The alert also shows a delete button that completely removes the item from the Firestore database.